### PR TITLE
Set VIRTUALENVWRAPPER_PYTHON=$(pyenv-which python) (if unset)

### DIFF
--- a/bin/pyenv-sh-virtualenvwrapper
+++ b/bin/pyenv-sh-virtualenvwrapper
@@ -9,6 +9,11 @@ set -e
 VIRTUALENVWRAPPER_SCRIPT="$(pyenv-which virtualenvwrapper.sh 2>/dev/null || true)"
 
 if [ -f "${VIRTUALENVWRAPPER_SCRIPT}" ]; then
+  if [ -z "$VIRTUALENVWRAPPER_PYTHON" ]; then
+    # Set/determine outermost python for wrapper (used with hooks), if not set already
+    VIRTUALENVWRAPPER_PYTHON="$(pyenv-which python 2>/dev/null || true)"
+  fi
+  echo "export VIRTUALENVWRAPPER_PYTHON=\"${VIRTUALENVWRAPPER_PYTHON}\";"
   echo "source \"${VIRTUALENVWRAPPER_SCRIPT}\""
 else
   echo "virtualenvwrapper not installed." 1>&2

--- a/bin/pyenv-sh-virtualenvwrapper_lazy
+++ b/bin/pyenv-sh-virtualenvwrapper_lazy
@@ -10,7 +10,12 @@ VIRTUALENVWRAPPER_SCRIPT="$(pyenv-which virtualenvwrapper.sh 2>/dev/null || true
 VIRTUALENVWRAPPER_LAZY_SCRIPT="$(pyenv-which virtualenvwrapper_lazy.sh 2>/dev/null || true)"
 
 if [ -f "${VIRTUALENVWRAPPER_LAZY_SCRIPT}" ]; then
+  if [ -z "$VIRTUALENVWRAPPER_PYTHON" ]; then
+    # Set/determine outermost python for wrapper (used with hooks), if not set already
+    VIRTUALENVWRAPPER_PYTHON="$(pyenv-which python 2>/dev/null || true)"
+  fi
   echo "export VIRTUALENVWRAPPER_SCRIPT=\"${VIRTUALENVWRAPPER_SCRIPT}\";"
+  echo "export VIRTUALENVWRAPPER_PYTHON=\"${VIRTUALENVWRAPPER_PYTHON}\";"
   echo "source \"${VIRTUALENVWRAPPER_LAZY_SCRIPT}\";"
 else
   echo "virtualenvwrapper not installed." 1>&2


### PR DESCRIPTION
This appears to be necessary, because when loading
virtualenvwrapper/pyenv-virtualenvwrapper after pyenv, it would use
~/.pyenv/shims/python and make it necessary to install virtualenvwrapper
in every virtualenv to make the hooks work.

The reasons for this are basically the same as for
VIRTUALENVWRAPPER_SCRIPT, I suppose.
Although this gets still set unconditionally always (e.g. in a tmux
subshell).
