### PR TITLE
Only call `pyenv which` once for the common case

### DIFF
--- a/bin/pyenv-virtualenvwrapper
+++ b/bin/pyenv-virtualenvwrapper
@@ -14,15 +14,19 @@ lib() {
     local STATUS=0
     if [[ "${PYENV_VIRTUALENVWRAPPER_PYENV_VERSION}" != "${version}" ]]; then
       unset PYENV_VIRTUALENVWRAPPER_PYENV_VERSION
-      pyenv which virtualenvwrapper.sh 1>/dev/null 2>&1 || (
-        local VIRTUALENVWRAPPER_VERSION="==${VIRTUALENVWRAPPER_VERSION}"
+      VIRTUALENVWRAPPER_SCRIPT="$(pyenv which virtualenvwrapper.sh 2>/dev/null || true)"
+      if [[ -z "$VIRTUALENVWRAPPER_SCRIPT" ]]; then
+        (
+          local VIRTUALENVWRAPPER_VERSION="==${VIRTUALENVWRAPPER_VERSION}"
 
-        unset PIP_REQUIRE_VENV
-        unset PIP_REQUIRE_VIRTUALENV
+          unset PIP_REQUIRE_VENV
+          unset PIP_REQUIRE_VIRTUALENV
 
-        pyenv exec pip install $QUIET $VERBOSE "virtualenvwrapper${VIRTUALENVWRAPPER_VERSION%==}" 1>&2
-      )
-      export VIRTUALENVWRAPPER_SCRIPT="$(pyenv which virtualenvwrapper.sh 2>/dev/null || true)"
+          pyenv exec pip install $QUIET $VERBOSE "virtualenvwrapper${VIRTUALENVWRAPPER_VERSION%==}" 1>&2
+        )
+        VIRTUALENVWRAPPER_SCRIPT="$(pyenv which virtualenvwrapper.sh 2>/dev/null || true)"
+      fi
+      export VIRTUALENVWRAPPER_SCRIPT
       export VIRTUALENVWRAPPER_LAZY_SCRIPT="$(pyenv which virtualenvwrapper_lazy.sh 2>/dev/null || true)"
       if [ ! -x "${VIRTUALENVWRAPPER_SCRIPT}" ] || [ ! -x "${VIRTUALENVWRAPPER_LAZY_SCRIPT}" ]; then
         echo "pyenv-virtualenvwrapper: ${version}: virtualenvwrapper is not available." 1>&2

--- a/test/virtualenvwrapper.bats
+++ b/test/virtualenvwrapper.bats
@@ -35,7 +35,6 @@ create_executable() {
 gen_script() {
   stub pyenv "version-name : echo \"${PYENV_VERSION}\""
   stub pyenv "which virtualenvwrapper.sh : echo \"${BATS_TEST_DIRNAME}/libexec/virtualenvwrapper.sh\""
-  stub pyenv "which virtualenvwrapper.sh : echo \"${BATS_TEST_DIRNAME}/libexec/virtualenvwrapper.sh\""
   stub pyenv "which virtualenvwrapper_lazy.sh : echo \"${BATS_TEST_DIRNAME}/libexec/virtualenvwrapper_lazy.sh\""
   stub pyenv "which virtualenv-clone : echo \"${PYENV_ROOT}/versions/${PYENV_VERSION}/bin/virtualenv-clone\""
   stub pyenv "which virtualenv : echo \"${PYENV_ROOT}/versions/${PYENV_VERSION}/bin/virtualenv\""
@@ -87,7 +86,6 @@ EOS
   script="$(gen_script)"
 
   stub pyenv "version-name : echo \"2.7.6\""
-  stub pyenv "which virtualenvwrapper.sh : echo \"${BATS_TEST_DIRNAME}/libexec/virtualenvwrapper.sh\""
   stub pyenv "which virtualenvwrapper.sh : echo \"${BATS_TEST_DIRNAME}/libexec/virtualenvwrapper.sh\""
   stub pyenv "which virtualenvwrapper_lazy.sh : echo \"${BATS_TEST_DIRNAME}/libexec/virtualenvwrapper_lazy.sh\""
   stub pyenv "which virtualenv-clone : echo \"${PYENV_ROOT}/versions/2.7.6/bin/virtualenv-clone\""

--- a/test/virtualenvwrapper_lazy.bats
+++ b/test/virtualenvwrapper_lazy.bats
@@ -35,7 +35,6 @@ create_executable() {
 gen_script() {
   stub pyenv "version-name : echo \"${PYENV_VERSION}\""
   stub pyenv "which virtualenvwrapper.sh : echo \"${BATS_TEST_DIRNAME}/libexec/virtualenvwrapper.sh\""
-  stub pyenv "which virtualenvwrapper.sh : echo \"${BATS_TEST_DIRNAME}/libexec/virtualenvwrapper.sh\""
   stub pyenv "which virtualenvwrapper_lazy.sh : echo \"${BATS_TEST_DIRNAME}/libexec/virtualenvwrapper_lazy.sh\""
   stub pyenv "which virtualenv-clone : echo \"${PYENV_ROOT}/versions/${PYENV_VERSION}/bin/virtualenv-clone\""
   stub pyenv "which virtualenv : echo \"${PYENV_ROOT}/versions/${PYENV_VERSION}/bin/virtualenv\""
@@ -85,7 +84,6 @@ EOS
   script="$(gen_script)"
 
   stub pyenv "version-name : echo \"3.3.3\""
-  stub pyenv "which virtualenvwrapper.sh : echo \"${BATS_TEST_DIRNAME}/libexec/virtualenvwrapper.sh\""
   stub pyenv "which virtualenvwrapper.sh : echo \"${BATS_TEST_DIRNAME}/libexec/virtualenvwrapper.sh\""
   stub pyenv "which virtualenvwrapper_lazy.sh : echo \"${BATS_TEST_DIRNAME}/libexec/virtualenvwrapper_lazy.sh\""
   stub pyenv "which virtualenv-clone : echo \"${PYENV_ROOT}/versions/3.3.3/bin/virtualenv-clone\""


### PR DESCRIPTION
If virtualenwrapper.sh is available, only call `pyenv which` once.

Ref: https://github.com/yyuu/pyenv-virtualenvwrapper/issues/13
