### PR TITLE
Handle 'pyenv version-name' failure in pyenv_virtualenvwrapper_load

### DIFF
--- a/bin/pyenv-virtualenvwrapper
+++ b/bin/pyenv-virtualenvwrapper
@@ -10,7 +10,11 @@ PYENV_VIRTUALENVWRAPPER_VERSION="20140609"
 
 lib() {
   pyenv_virtualenvwrapper_load() {
-    local version="$(pyenv version-name)"
+    local version="$(pyenv version-name 2>/dev/null || true)"
+    if [[ -z "$version" ]]; then
+      echo "pyenv-virtualenvwrapper: python is not available." 1>&2
+      return 1
+    fi
     if [[ "${PYENV_VIRTUALENVWRAPPER_PYENV_VERSION}" != "${version}" ]]; then
       unset PYENV_VIRTUALENVWRAPPER_PYENV_VERSION
 


### PR DESCRIPTION
Before:

```
% pyenv version
pyenv: version `2.7.9rc1' is not installed
(eval):source:80: no such file or directory:
pyenv: version `2.7.9rc1' is not installed
```

After:

```
% pyenv version
pyenv: version `2.7.9rc1' is not installed
pyenv-virtualenvwrapper: python is not available.
pyenv-virtualenvwrapper: failed to initialize virtualenvwrapper_lazy.
pyenv: version `2.7.9rc1' is not installed
```
